### PR TITLE
Update dependences

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,6 @@
+require: rubocop-jekyll
 inherit_gem:
-  jekyll: .rubocop.yml
+  rubocop-jekyll: .rubocop.yml
 
 AllCops:
   TargetRubyVersion: 2.4

--- a/jekyll-target-blank.gemspec
+++ b/jekyll-target-blank.gemspec
@@ -23,5 +23,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 12.0"
   spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_development_dependency "rubocop", "0.55"
+  spec.add_development_dependency "rubocop-jekyll", "~> 0.10.0"
 end

--- a/jekyll-target-blank.gemspec
+++ b/jekyll-target-blank.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.required_ruby_version = ">= 2.4.0"
 
-  spec.add_dependency "jekyll", "~> 3.0"
+  spec.add_dependency "jekyll", "~> 3.8"
   spec.add_dependency "nokogiri", "~> 1.9"
 
   spec.add_development_dependency "bundler", "~> 2.0"

--- a/lib/jekyll-target-blank.rb
+++ b/lib/jekyll-target-blank.rb
@@ -153,20 +153,15 @@ module Jekyll
       #
       # link = Nokogiri node.
       def add_rel_attributes(link)
-        rel = ""
-        rel = "noopener" if @should_add_noopener
+        rel_list = []
 
-        if @should_add_noreferrrer
-          rel += " " unless rel.empty?
-          rel += "noreferrer"
-        end
+        rel_list << "noopener" if @should_add_noopener
 
-        if @should_add_extra_rel_attribute_values
-          rel += " " unless rel.empty?
-          rel += @extra_rel_attribute_values
-        end
+        rel_list << "noreferrer" if @should_add_noreferrrer
 
-        link["rel"] = rel unless rel.empty?
+        rel_list << @extra_rel_attribute_values if @should_add_extra_rel_attribute_values
+
+        link["rel"] = rel_list.join(" ") unless rel_list.empty?
       end
 
       # Private: Checks if the link is a mailto url.

--- a/lib/jekyll-target-blank.rb
+++ b/lib/jekyll-target-blank.rb
@@ -7,7 +7,7 @@ require "uri"
 module Jekyll
   class TargetBlank
     BODY_START_TAG         = "<body"
-    OPENING_BODY_TAG_REGEX = %r!<body([^<>]*)>\s*!
+    OPENING_BODY_TAG_REGEX = %r!<body([^<>]*)>\s*!.freeze
 
     class << self
       # Public: Processes the content and updated the external links
@@ -117,13 +117,9 @@ module Jekyll
 
       # Private: Handles the default rel attribute values
       def add_default_rel_attributes?
-        if should_not_include_noopener?
-          @should_add_noopener = false
-        end
+        @should_add_noopener = false if should_not_include_noopener?
 
-        if should_not_include_noreferrer?
-          @should_add_noreferrrer = false
-        end
+        @should_add_noreferrrer = false if should_not_include_noreferrer?
       end
 
       # Private: Sets any extra rel attribute values
@@ -158,27 +154,19 @@ module Jekyll
       # link = Nokogiri node.
       def add_rel_attributes(link)
         rel = ""
-        if @should_add_noopener
-          rel = "noopener"
-        end
+        rel = "noopener" if @should_add_noopener
 
         if @should_add_noreferrrer
-          unless rel.empty?
-            rel += " "
-          end
+          rel += " " unless rel.empty?
           rel += "noreferrer"
         end
 
         if @should_add_extra_rel_attribute_values
-          unless rel.empty?
-            rel += " "
-          end
+          rel += " " unless rel.empty?
           rel += @extra_rel_attribute_values
         end
 
-        unless rel.empty?
-          link["rel"] = rel
-        end
+        link["rel"] = rel unless rel.empty?
       end
 
       # Private: Checks if the link is a mailto url.
@@ -332,6 +320,6 @@ module Jekyll
 end
 
 # Hooks into Jekyll's post_render event.
-Jekyll::Hooks.register %i[pages documents], :post_render do |doc|
+Jekyll::Hooks.register [:pages, :documents], :post_render do |doc|
   Jekyll::TargetBlank.process(doc) if Jekyll::TargetBlank.document_processable?(doc)
 end

--- a/spec/jekyll-target_spec.rb
+++ b/spec/jekyll-target_spec.rb
@@ -12,13 +12,11 @@ RSpec.describe(Jekyll::TargetBlank) do
   end
   let(:configs) do
     Jekyll.configuration(config_overrides.merge(
-      {
-        "skip_config_files" => false,
-        "collections"       => { "docs" => { "output" => true } },
-        "source"            => unit_fixtures_dir,
-        "destination"       => unit_fixtures_dir("_site"),
-      }
-    ))
+                           "skip_config_files" => false,
+                           "collections"       => { "docs" => { "output" => true } },
+                           "source"            => unit_fixtures_dir,
+                           "destination"       => unit_fixtures_dir("_site")
+                         ))
   end
   let(:target_blank) { described_class }
   let(:site) { Jekyll::Site.new(configs) }
@@ -425,22 +423,22 @@ RSpec.describe(Jekyll::TargetBlank) do
   private
 
   def post_with_layout_result
-    <<-RESULT
-<!DOCTYPE HTML>
-<html lang="en-US">
-<head>
-    <meta charset="UTF-8">
-    <title>Post with external markdown link</title>
-    <meta name="viewport" content="width=device-width,initial-scale=1">
-    <link rel="stylesheet" href="/css/screen.css">
-</head>
-<body class="wrap">
-    <div>Layout content started.</div>
-<p>Link to <a href="https://google.com" target="_blank" rel="noopener noreferrer">Google</a>.</p>
+    <<~RESULT
+      <!DOCTYPE HTML>
+      <html lang="en-US">
+      <head>
+          <meta charset="UTF-8">
+          <title>Post with external markdown link</title>
+          <meta name="viewport" content="width=device-width,initial-scale=1">
+          <link rel="stylesheet" href="/css/screen.css">
+      </head>
+      <body class="wrap">
+          <div>Layout content started.</div>
+      <p>Link to <a href="https://google.com" target="_blank" rel="noopener noreferrer">Google</a>.</p>
 
-    <div>Layout content ended.</div>
-</body>
-</html>
+          <div>Layout content ended.</div>
+      </body>
+      </html>
     RESULT
   end
 end


### PR DESCRIPTION
- Use jekyll-rubocop instead of pure rubocop
  - jekyll-rubocop is official gem by jekyll
  - Refactor `add_rel_attributes` method
- Bump version jekyll dependences
  - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-11068