### PR TITLE
Add support for Unicode links

### DIFF
--- a/lib/jekyll-target-blank.rb
+++ b/lib/jekyll-target-blank.rb
@@ -176,7 +176,7 @@ module Jekyll
       # link - a url.
       def external?(link)
         if link&.match?(URI.regexp(%w(http https)))
-          URI.parse(link).host != URI.parse(@site_url).host
+          URI.parse(CGI.escape(link)).host != URI.parse(CGI.escape(@site_url)).host
         end
       end
 

--- a/lib/jekyll-target-blank/version.rb
+++ b/lib/jekyll-target-blank/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module JekyllTargetBlank
-  VERSION = "1.1.1"
+  VERSION = "1.1.2"
 end


### PR DESCRIPTION
* In function 'external?', URI is now escaped before split.
* This adheres to the recommendation in the URI docs: https://www.rubydoc.info/stdlib/uri/URI.parse
* Using CGI.escape instead of URI.escape as the latter is marked obsolete.
* Resolves keithmifsud/jekyll-target-blank#33
* I'm asking for pull request here, since the original repository does not seem to be maintained anymore.